### PR TITLE
 Critical fix: don't modify response if debugbar disabled

### DIFF
--- a/src/LaravelDebugbarVscode.php
+++ b/src/LaravelDebugbarVscode.php
@@ -58,6 +58,10 @@ class LaravelDebugbarVscode extends ServiceProvider
      */
     public function modifyResponse(Request $request, Response $response)
     {
+        if (!$this->app->make(LaravelDebugbar::class)->isEnabled()) {
+            return $response;
+        }
+        
         try {
             $header = $request->header('Accept');
             if (strpos($header, 'html') !== false) {


### PR DESCRIPTION
i.e. when running tests the response gets modified