### PR TITLE
 Critical fix: don't modify response if debugbar disabled

### DIFF
--- a/src/LaravelDebugbarVscode.php
+++ b/src/LaravelDebugbarVscode.php
@@ -58,6 +58,11 @@ class LaravelDebugbarVscode extends ServiceProvider
      */
     public function modifyResponse(Request $request, Response $response)
     {
+        if (! class_exists('\Barryvdh\Debugbar\LaravelDebugbar')
+            || ! $this->app->make('\Barryvdh\Debugbar\LaravelDebugbar')->isEnabled()) {
+            return $response;
+        }
+        
         try {
             $header = $request->header('Accept');
             if (strpos($header, 'html') !== false) {


### PR DESCRIPTION
i.e. when running request tests, prevent the response from being modified